### PR TITLE
add yarn.lock to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM node:lts-alpine
 
 RUN mkdir /app
 WORKDIR /app
-COPY package*.json ./
+COPY package.json ./
+COPY yarn.lock ./
 RUN yarn install
 COPY . ./
 EXPOSE 3000


### PR DESCRIPTION
prevent wrong package dependencies to be installed when building container